### PR TITLE
Fix code formatting in README.mb

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ your PATH.
 The extractor is provided as part of the essentia project. You can compile
 your own extractor if you want. Just download essentia and compile it with examples
 
-   ./waf configure --with-examples
-   ./waf
+    ./waf configure --with-examples
+    ./waf
 
 and get the resulting file from `build/src/examples/streaming_extractor_music`
 


### PR DESCRIPTION
The two ./waf lines were running together because it needed an extra space.
