### PR TITLE
Expand '~' in user config path if needed.

### DIFF
--- a/abz/config.py
+++ b/abz/config.py
@@ -18,9 +18,9 @@ def load_settings():
 
     essentia = config.get("essentia", "path")
     if not os.path.isabs(essentia):
-        essentia = os.path.abspath(essentia)
+        essentia = os.path.abspath(os.path.expanduser(essentia))
     if not os.path.exists(essentia):
-        raise Exception ("Cannot find the extractor")
+        raise Exception ("Cannot find the extractor %r" % essentia)
 
     h = hashlib.sha1()
     h.update(open(essentia, "rb").read())


### PR DESCRIPTION
It allows user to set path as "path: ~/mypath" in the config file.

Also includes the failing path in the exception message.
