### PR TITLE
Remove dupe "mp4" and group extensions somewhat.

### DIFF
--- a/abz/default.conf
+++ b/abz/default.conf
@@ -1,7 +1,7 @@
 [acousticbrainz]
 host: acousticbrainz.org
 #host: localhost:4000
-extensions: mp3 ogg flac m4a aac mp4 wma oga mpc wv spx tta m4r m4b m4p 3g2 mp4 asf aif aiff ape
+extensions: mp3 ogg oga flac mp4 m4a m4r m4b m4p aac wma asf mpc wv spx tta 3g2 aif aiff ape
 
 [essentia]
 path: streaming_extractor_music


### PR DESCRIPTION
7b8e175140345a9ba2e05bf81176dbd2fb482737 introduced `mp4` after it was added by efdeb1c4307a607ea7d911c314f811c3be00087f. This removes the duplicate and groups the other extensions somewhat.
