### PR TITLE
Import distutils.spawn in config.py.

### DIFF
--- a/abz/config.py
+++ b/abz/config.py
@@ -5,6 +5,7 @@
 from __future__ import print_function
 
 import distutils
+import distutils.spawn
 import ConfigParser
 import os
 import sys


### PR DESCRIPTION
Without this, abzsubmit fails for me with "AttributeError: 'module' object has no attribute 'spawn'".
