### PR TITLE
Move extractor from `scripts` to `data_files`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     packages=['abz'],
     package_data={'abz': ['default.conf']},
     scripts = ['abzsubmit'],
-    data_files = [('', ['streaming_extractor_music'])],
+    data_files = [('bin', ['streaming_extractor_music'])],
     license='GPL3+',
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
`scripts` is meant to be for Python scripts:

> Scripts are files containing Python source code, intended to be started from the command line.
> https://docs.python.org/2/distutils/setupscript.html#installing-scripts

The extractor is not a Python script and as thus isn't a good fit for being listed under `scripts`. It doesn't seem to fall into any of the other categories, which makes it fall into the category of files `data_files` is meant for:

> The `data_files` option can be used to specify additional files needed by the module distribution: configuration files, message catalogs, data files, anything which doesn’t fit in the previous categories.
> https://docs.python.org/2/distutils/setupscript.html#installing-additional-files

Should also fix #24.
