### PR TITLE
Enable Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: python
+python:
+  - "2.6"
+  - "2.7"
+  - "pypy"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "pypy3"
+cache:
+  directories:
+    - $HOME/.pip/cache
+before_install:
+  - wget -O - ftp://vm.musicbrainz.org/pub/acousticbrainz/extractors/essentia-extractor-21ef5f41f15ed1f80c8f9b36802430055d3b93e9-linux-x86_64.tar.gz | tar -xvz --strip-components=1
+install:
+  # Install dependencies
+  - pip install --download-cache='$HOME/.pip/cache' --use-mirrors -r requirements.txt
+  # Setup abzsubmit
+  - python setup.py install
+# Try running the client
+# There's currently not a proper test suite, so the test is mostly just a "will
+# it run" type of test.
+script:
+  - ./abzsubmit $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,6 @@ install:
 # it run" type of test.
 script:
   - ./abzsubmit $HOME
+# Notify people that tests were run
+notifications:
+  irc: "chat.freenode.net#musicbrainz-devel"

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - wget -O - ftp://vm.musicbrainz.org/pub/acousticbrainz/extractors/essentia-extractor-21ef5f41f15ed1f80c8f9b36802430055d3b93e9-linux-x86_64.tar.gz | tar -xvz --strip-components=1
 install:
   # Install dependencies
-  - pip install --download-cache='$HOME/.pip/cache' --use-mirrors -r requirements.txt
+  - pip install --download-cache='$HOME/.pip/cache' -r requirements.txt
   # Setup abzsubmit
   - python setup.py install
 # Try running the client


### PR DESCRIPTION
Go to https://travis-ci.org/profile/MTG and enable MTG/acousticbrainz-client then go to settings (the wrench icon) and turn "Build only if .travis.yml is present" on.

Note that the Python 3 tests are currently failing due to #25/#26, but should hopefully work once they do. (This making #25/#26 the first bug to be found due to this testing, and it's not even enabled yet! :+1:)
