### PR TITLE
Fix Python 3 encoding for error messages and `VERBOSE` output

### DIFF
--- a/abz/acousticbrainz.py
+++ b/abz/acousticbrainz.py
@@ -30,7 +30,7 @@ GREEN = "\x1b[32m"
 def _update_progress(msg, status="...", colour=RESET):
     if VERBOSE:
         sys.stdout.write("%s[%-10s]%s " % (colour, status, RESET))
-        print(msg.encode("ascii", "ignore"))
+        print(compat.output(msg))
     else:
         sys.stdout.write("%s[%-10s]%s " % (colour, status, RESET))
         sys.stdout.write(msg+"\x1b[K\r")

--- a/abz/compat.py
+++ b/abz/compat.py
@@ -19,10 +19,29 @@ else:
     from urllib.parse import urlunparse
     from configparser import RawConfigParser
 
+
+try:
+    unicode_string = unicode    # Python 2
+except NameError:
+    unicode_string = str        # Python 3 doesn't have unicode type
+
+
+# currently not used
+def encode(msg):
+    """encode if msg is a unicode string, no-op otherwise
+    """
+    if isinstance(msg, unicode_string):
+        # TODO: sys.stdout.encoding and replace might be used later
+        # ascii is taken from previous code!
+        return msg.encode("ascii", "ignore")
+    else:
+        return msg
+
 def decode(msg):
     """decode if msg is a byte string, no-op otherwise
     """
     if isinstance(msg, bytes):
+        # TODO: sys.stdin.encoding might be used later
         return msg.decode("utf-8", "replace")
     else:
         return msg


### PR DESCRIPTION
The extractor always returns byte strings, which is fine for Python 2.
Python 3 `print()` expects unicode strings, rather than byte strings. So if `str == byte` (Python 2) we do nothing. Otherwise we decode the msg if it isn't already a unicode string.

There was a different problem when `VERBOSE` was activated. An the byte string coming from the extractor was encoded again (which is fine as long as it is ascii on Python 2), but as above, using `print()` with a byte string on Python 3 is wrong.

The result on Python 3 with errors without this fix is this:

```
[:( unk 5  ] /var/data/music/mp3-db/In Strict Confidence/2002: Mistrust the Angels/09 - In Strict Confidence - It Seems Lost....mp3
b'Process step: Read metadata\nProcess step: Compute md5 audio hash and codec\n\x1b[0;33m[ WARNING  ] \x1b[0mAudioLoader: invalid frame, skipping it: Invalid data found when processing input\nProcess step: Replay gain\n\x1b[0;33m[ WARNING  ] \x1b[0mAudioLoader: invalid frame, skipping it: Invalid data found when processing input\n\x1b[0;33m[ WARNING  ] \x1b[0mAudioLoader: invalid frame, skipping it: Invalid data found when processing input\nERROR: File looks like a completely silent file... Aborting...\n'
```

I also added a `compat.encode()`, which was used until I found out even the previous `encode()` was misplaced (see above). I kept it in the code unused. It might help out later on.

Note that I have "utf-8" and "ascii" as encodings in `compat.py` since that was in the code I was replacing.
This should probably replaced with `sys.stdout/stdin.encoding`. I left in comments about that.

Getting Unicode output to work on Windows is a different beast.
For the problem and the solution have a look in JonnyJD/isrcsubmit#40 and/or 8f931940ec9b45e2ee72db0bc19e97a9f25bf6f2.
Short: You have to make a wrapper to change the codepage to cp65001 and tell Python that this is "~ utf-8".
