### PR TITLE
Fix AB-293: Reraise errors on reprocessing files

### DIFF
--- a/abz/acousticbrainz.py
+++ b/abz/acousticbrainz.py
@@ -62,10 +62,7 @@ def is_processed(filepath):
     query = """select * from filelog where filename = ?"""
     c = conn.cursor()
     r = c.execute(query, (compat.decode(filepath), ))
-    if len(r.fetchall()):
-        return True
-    else:
-        return False
+    return not all([result[2] for result in r.fetchall()])
 
 
 def run_extractor(input_path, output_path):


### PR DESCRIPTION
Fix for the issue -
https://tickets.metabrainz.org/browse/AB-293

Currently files that were reprocessed, exited with `:) done` status as `is_processed` returned `True`. `is_processed` now only returns `True` if the file was _successfully processed_

Tested locally.

![screenshot from 2017-01-05 02-05-10](https://cloud.githubusercontent.com/assets/12889549/21658164/72488262-d2eb-11e6-889e-755a35e10820.png)
