### PR TITLE
AB-369: acousticbrainz-client on linux does not support https

### DIFF
--- a/abz/acousticbrainz.py
+++ b/abz/acousticbrainz.py
@@ -99,7 +99,7 @@ def submit_features(recordingid, features):
             urllib3.contrib.pyopenssl.inject_into_urllib3()
         except ImportError:
             pass
-    if host[:10] == "localhost": 
+    if host[:9] == "localhost": 
         url = compat.urlunparse(
             ('http', host, '/%s/low-level' % recordingid, '', '', ''))
     else:

--- a/abz/acousticbrainz.py
+++ b/abz/acousticbrainz.py
@@ -93,7 +93,18 @@ def submit_features(recordingid, features):
     featstr = json.dumps(features)
 
     host = config.settings["host"]
-    url = compat.urlunparse(('http', host, '/%s/low-level' % recordingid, '', '', ''))
+    if sys.version_info < (3, 0):
+        try:
+            import urllib3.contrib.pyopenssl
+            urllib3.contrib.pyopenssl.inject_into_urllib3()
+        except ImportError:
+            pass
+    if host[:10] == "localhost": 
+        url = compat.urlunparse(
+            ('http', host, '/%s/low-level' % recordingid, '', '', ''))
+    else:
+        url = compat.urlunparse(
+            ('https', host, '/%s/low-level' % recordingid, '', '', ''))
     r = requests.post(url, data=featstr)
     r.raise_for_status()
 

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,8 @@ setup(
     package_data={'abz': ['default.conf']},
     scripts=['abzsubmit'],
     data_files=[('bin', ['streaming_extractor_music'])],
-    install_requires=['requests>2.4'],
+    install_requires=['requests>2.4',
+                      'pyopenssl>0.13', 'ndg-httpsclient>0.3.2', 'pyasn1>0.1.6'],
     license='GPL3+',
     classifiers=[
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
- As described in https://tickets.metabrainz.org/browse/AB-369 by @alastair , changes were made to files where the acousticbrainz-client was connecting to the Host to submit data.
- Added support for python 2. versions to do SNI   