### PR TITLE
Specify supported version(s) of Python in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,7 @@ setup(
     package_data={'abz': ['default.conf']},
     scripts=['abzsubmit'],
     data_files=[('bin', ['streaming_extractor_music'])],
+    python_requires='>=2.6',
     install_requires=['requests>2.4'],
     license='GPL3+',
     classifiers=[


### PR DESCRIPTION
This specifies which versions of Python the library is compatible with. This both prevents the module from being installed in an incompatible Python environment, and will also enable users after future releases to still `pip install musicbrainzngs` and get a version that is compatible with their Python setup.

Versions specified according to current README.md.

See https://packaging.python.org/guides/dropping-older-python-versions/ and https://github.com/pypa/sampleproject/pull/87